### PR TITLE
Add implementation of the snap Openstack Network Agents

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# snap-openstack-network-agents
+# OpenStack Network Agents (snap)
+
+This snap provides the `neutron-ovn-metadata-agent` and helpers for Sunbeam
+**network-role** nodes. It is designed to be co-located with `microovn`.
+
+## Install
+
+```bash
+sudo snap install openstack-network-agents --classic
+```
+
+**NOTE:** Classic confinement is required to access `/var/run/openvswitch/db.sock`.
+
+## Configure
+
+The snap can configure the provider bridge and physnet mapping:
+
+```bash
+sudo snap set openstack-network-agents \
+  external-interface=enp6s0 \
+  bridge-name=br-ex \
+  physnet-name=physnet1
+```
+
+Then (re)start the agent:
+
+```bash
+sudo snap start openstack-network-agents.metadata-agent
+```
+
+## Service
+
+```bash
+sudo snap services openstack-network-agents
+```

--- a/snap/files/bin/bridge-setup
+++ b/snap/files/bin/bridge-setup
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+log(){ echo "bridge-setup: $*" >&2; }
+die(){ echo "bridge-setup ERROR: $*" >&2; exit 1; }
+
+apply_from_snap_config() {
+  local iface bridge phys
+  iface="$(snapctl get network.interface || true)"
+  bridge="$(snapctl get network.bridge || true)"; : "${bridge:=br-ex}"
+  phys="$(snapctl get network.physnet || true)"; : "${phys:=physnet1}"
+  [[ -n "$iface" ]] || { log "no network.interface set; skipping"; exit 0; }
+  ensure_bridge_and_mapping "${bridge}" "${iface}" "${phys}"
+}
+
+ensure_bridge_and_mapping() {
+  local br="$1" ifc="$2" phys="$3"
+  local ovsctl=""
+  if [[ -x "${SNAP}/usr/bin/ovs-vsctl" ]]; then
+    ovsctl="${SNAP}/usr/bin/ovs-vsctl"
+  elif [[ -x /snap/microovn/current/usr/bin/ovs-vsctl ]]; then
+    ovsctl="/snap/microovn/current/usr/bin/ovs-vsctl"
+  fi
+  [[ -n "$ovsctl" ]] || die "ovs-vsctl not found; stage openvswitch-switch into the snap"
+
+  local dbopt=""
+  if [[ -S /var/snap/microovn/common/run/switch//db.sock ]]; then
+    dbopt="--db=unix:/var/snap/microovn/common/run/switch//db.sock"
+  elif [[ -S /var/run/openvswitch/db.sock ]]; then
+    dbopt="--db=unix:/var/run/openvswitch/db.sock"
+  fi
+
+  # Ovsctl wrapper that adds --db option if a socket is found
+  ovs() { "$ovsctl" ${dbopt:+$dbopt} "$@"; }
+
+  if [[ -n "$ovsctl" ]]; then
+    ovs --may-exist add-br "$br"
+    ovs --may-exist add-port "$br" "$ifc"
+    ip link set dev "$br" up || true
+    ip link set dev "$ifc" up || true
+    local current
+    current=$(ovs --if-exists get Open_vSwitch . external_ids:ovn-bridge-mappings 2>/dev/null | tr -d '"') || current=""
+    if [[ "$current" == *"$phys:$br"* ]]; then
+      log "mapping $phys:$br already present"
+    else
+      if [[ -n "$current" && "$current" != "[]" ]]; then
+        ovs set Open_vSwitch . external_ids:ovn-bridge-mappings="${current},${phys}:${br}"
+      else
+        ovs set Open_vSwitch . external_ids:ovn-bridge-mappings="${phys}:${br}"
+      fi
+      log "set mapping ${phys}:${br}"
+    fi
+
+    local mac cur_mac_map updated_mac_map replaced
+    mac="$(cat "/sys/class/net/${br}/address" 2>/dev/null || true)"
+    if [[ -z "$mac" ]]; then
+      mac="$(ip -o link show "$br" 2>/dev/null | awk -F'link/ether ' '{print $2}' | awk '{print $1}')"
+    fi
+    if [[ -n "$mac" && "$mac" != "00:00:00:00:00:00" ]]; then
+      cur_mac_map=$(ovs --if-exists get Open_vSwitch . external_ids:ovn-chassis-mac-mappings 2>/dev/null | tr -d '"' || true)
+      [[ "$cur_mac_map" == "[]" ]] && cur_mac_map=""
+
+      if [[ -z "$cur_mac_map" ]]; then
+        updated_mac_map="${phys}:${mac}"
+      else
+        IFS=',' read -r -a parts <<< "$cur_mac_map"
+        updated_mac_map=""
+        replaced=0
+        for ent in "${parts[@]}"; do
+          [[ -z "$ent" ]] && continue
+          if [[ "$ent" == "$phys:"* ]]; then
+            ent="${phys}:${mac}"
+            replaced=1
+          fi
+          updated_mac_map="${updated_mac_map:+$updated_mac_map,}${ent}"
+        done
+        if [[ "$replaced" -eq 0 ]]; then
+          updated_mac_map="${updated_mac_map:+$updated_mac_map,}${phys}:${mac}"
+        fi
+      fi
+      ovs set Open_vSwitch . external_ids:ovn-chassis-mac-mappings="${updated_mac_map}"
+      log "set chassis-mac mapping ${phys}:${mac}"
+    else
+      log "could not determine MAC for ${ifc}; skipping chassis-mac mapping"
+    fi
+
+    local gw cms newcms
+    gw="$(snapctl get network.enable-chassis-as-gw || true)"
+    if [[ "${gw,,}" == "true" ]]; then
+      cms="$(ovs --if-exists get Open_vSwitch . external_ids:ovn-cms-options 2>/dev/null | tr -d '"' || true)"
+      [[ "$cms" == "[]" ]] && cms=""
+      if [[ "$cms" != *"enable-chassis-as-gw"* ]]; then
+        newcms="${cms:+$cms,}enable-chassis-as-gw"
+        ovs set Open_vSwitch . external_ids:ovn-cms-options="${newcms}"
+        log "enabled gateway role (ovn-cms-options=${newcms})"
+      else
+        log "gateway role already enabled (ovn-cms-options=${cms})"
+      fi
+    fi
+
+  else
+    ip link show "$br" >/dev/null 2>&1 || ip link add "$br" type bridge
+    ip link set "$ifc" down || true
+    ip link set "$ifc" master "$br" || true
+    ip link set "$br" up
+    ip link set "$ifc" up
+  fi
+}
+
+case "${1:-}" in
+  apply-from-snap-config) apply_from_snap_config ;;
+  ensure)                 ensure_bridge_and_mapping "${2:?br}" "${3:?iface}" "${4:?physnet}" ;;
+  *) echo "Usage: bridge-setup apply-from-snap-config | ensure <br> <iface> <physnet>" >&2; exit 2 ;;
+esac

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+"$SNAP"/files/bin/bridge-setup apply-from-snap-config || exit 0

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if snapctl get external-interface >/dev/null 2>&1; then
+  "$SNAP"/files/bin/bridge-setup apply-from-snap-config || true
+fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,47 @@
+name: openstack-network-agents
+summary: OVS provider-bridge helper for OpenStack Network role
+description: |
+  Provides a helper to configure a provider bridge and OVN physnet mapping.
+  This snap is meant to be driven by a subordinate charm and does not ship
+  neutron-ovn-metadata-agent.
+base: core24
+version: "0.1"
+license: Apache-2.0
+grade: devel
+confinement: strict
+
+plugs:
+  network-control:
+    interface: network-control
+  network:
+    interface: network
+  ovn-chassis:
+    interface: content
+    target: $SNAP_DATA/microovn/chassis
+
+apps:
+  bridge-setup:
+    command: files/bin/bridge-setup
+    plugs:
+      - network
+      - network-control
+      - ovn-chassis
+
+parts:
+  agents:
+    plugin: dump
+    source: .
+    stage-packages:
+      - iproute2
+      - openvswitch-switch
+    override-build: |
+      set -euxo pipefail
+      craftctl default
+      install -D -m755 "$CRAFT_PROJECT_DIR/snap/files/bin/bridge-setup" \
+                       "$CRAFT_PART_INSTALL/files/bin/bridge-setup"
+
+hooks:
+  install:
+    plugs: [network, network-control, ovn-chassis]
+  configure:
+    plugs: [network, network-control, ovn-chassis]


### PR DESCRIPTION
This PR adds the implementation for the snap Openstack Network Agents, which sets the following components for ovs:
- external_ids:ovn-bridge-mappings
- ovn-chassis-mac-mappings (https://github.com/openstack-charmers/charm-layer-ovn/pull/98)
- ovn-cms-options=enable-chassis-as-gw