### PR TITLE
feat: add localnet mode support for single-node deployments 

### DIFF
--- a/openstack_network_agents/cli/setup_bridge.py
+++ b/openstack_network_agents/cli/setup_bridge.py
@@ -37,5 +37,6 @@ def setup_bridge(ctx: click.Context) -> None:
         config("network.interface"),
         config("network.bridge-mapping"),
         config("network.enable-chassis-as-gw") in ("true", True),
+        config("network.external-bridge-address"),
         ovs_cli,
     )

--- a/openstack_network_agents/core/external_networking.py
+++ b/openstack_network_agents/core/external_networking.py
@@ -1,10 +1,15 @@
 # SPDX-FileCopyrightText: 2025 - Canonical Ltd
 # SPDX-License-Identifier: Apache-2.0
 
+import errno
+import ipaddress
 import logging
+import re
+import subprocess
 import time
 
 from pyroute2 import IPRoute
+from pyroute2.netlink.exceptions import NetlinkError
 
 from openstack_network_agents.core.bridge_datapath import (
     OVSCli,
@@ -13,6 +18,7 @@ from openstack_network_agents.core.bridge_datapath import (
     resolve_ovs_changes,
     update_mappings_from_rename,
 )
+from openstack_network_agents.hooks.common import IPVANYNETWORK_UNSET
 
 logger = logging.getLogger(__name__)
 
@@ -138,6 +144,122 @@ def _ensure_link_up(interface: str):
     ipr.link("set", index=dev, state="up")  # type: ignore[attr-defined]
 
 
+def _add_ip_to_interface(interface: str, cidr: str) -> None:
+    """Add IP to interface and set link to up.
+
+    Deletes any existing IPs on the interface and set IP
+    of the interface to cidr.
+
+    :param interface: interface name
+    :type interface: str
+    :param cidr: network address
+    :type cidr: str
+    :return: None
+    """
+    logging.debug(f"Adding  ip {cidr} to {interface}")
+    ipr = IPRoute()
+    dev = ipr.link_lookup(ifname=interface)[0]  # type: ignore[attr-defined]
+    ip_mask = cidr.split("/")
+    try:
+        ipr.addr("add", index=dev, address=ip_mask[0], mask=int(ip_mask[1]))  # type: ignore[attr-defined]
+    except NetlinkError as e:
+        if e.code != errno.EEXIST:
+            raise e
+
+    ipr.link("set", index=dev, state="up")  # type: ignore[attr-defined]
+
+
+def _add_iptable_postrouting_rule(cidr: str, comment: str) -> None:
+    """Add postrouting iptable rule.
+
+    Add new postiprouting iptable rule, if it does not exist, to allow traffic
+    for cidr network.
+    """
+    executable = "iptables-legacy"
+    rule_def = [
+        "POSTROUTING",
+        "-w",
+        "-t",
+        "nat",
+        "-s",
+        cidr,
+        "-j",
+        "MASQUERADE",
+        "-m",
+        "comment",
+        "--comment",
+        comment,
+    ]
+    found = False
+    try:
+        cmd = [executable, "--check"]
+        cmd.extend(rule_def)
+        logging.debug(cmd)
+        subprocess.run(cmd, capture_output=True, check=True)
+    except subprocess.CalledProcessError as e:
+        # --check has an RC of 1 if the rule does not exist
+        if e.returncode == 1 and re.search(
+            r"No.*match by that name", e.stderr.decode()
+        ):
+            logging.debug(f"Postrouting iptable rule for {cidr} missing")
+            found = False
+        else:
+            logging.warning(f"Failed to lookup postrouting iptable rule for {cidr}")
+    else:
+        # If not exception was raised then the rule exists.
+        logging.debug(f"Found existing postrouting rule for {cidr}")
+        found = True
+    if not found:
+        logging.debug(f"Adding postrouting iptable rule for {cidr}")
+        cmd = [executable, "--append"]
+        cmd.extend(rule_def)
+        logging.debug(cmd)
+        subprocess.check_call(cmd)
+
+
+def _delete_iptable_postrouting_rule(comment: str) -> None:
+    """Delete postrouting iptable rules based on comment."""
+    logging.debug("Resetting iptable rules added by openstack-hypervisor")
+    if not comment:
+        return
+
+    try:
+        cmd = [
+            "iptables-legacy",
+            "-t",
+            "nat",
+            "-n",
+            "-v",
+            "-L",
+            "POSTROUTING",
+            "--line-numbers",
+        ]
+        process = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        iptable_rules = process.stdout.strip()
+
+        line_numbers = [
+            line.split(" ")[0] for line in iptable_rules.split("\n") if comment in line
+        ]
+
+        # Delete line numbers in descending order
+        # If a lower numbered line number is deleted, iptables
+        # changes lines numbers of high numbered rules.
+        line_numbers.sort(reverse=True)
+        for number in line_numbers:
+            delete_rule_cmd = [
+                "iptables-legacy",
+                "-t",
+                "nat",
+                "-D",
+                "POSTROUTING",
+                number,
+            ]
+            logging.debug(f"Deleting iptable rule: {delete_rule_cmd}")
+            subprocess.check_call(delete_rule_cmd)
+    except subprocess.CalledProcessError as e:
+        logging.info(f"Error in deletion of IPtable rule: {e.stderr}")
+
+
 def _enable_chassis_as_gateway(ovs_cli: OVSCli):
     """Enable OVS as an external chassis gateway."""
     logging.info("Enabling OVS as external gateway")
@@ -161,6 +283,7 @@ def configure_ovn_external_networking(
     interface: str,
     bridge_mapping: str,
     enable_chassis_as_gw: bool,
+    external_bridge_address: str,
     ovs_cli: OVSCli,
 ) -> None:
     """Configure OVN external networking.
@@ -170,6 +293,7 @@ def configure_ovn_external_networking(
     :param interface: network.interface configuration
     :param bridge_mapping: network.bridge-mapping configuration
     :param enable_chassis_as_gw: network.enable-chassis-as-gw configuration (boolean)
+    :param external_bridge_address: network.external-bridge-address configuration
     :param ovs_cli: OVS CLI interface
     :return: None
     """
@@ -181,12 +305,23 @@ def configure_ovn_external_networking(
         interface,
         bridge_mapping,
     )
+    if not mappings:
+        logging.info(
+            "No valid bridge mappings found; skipping external network configuration."
+        )
+        return
     current_mappings = detect_current_mappings(ovs_cli)
 
     changes = resolve_ovs_changes(current_mappings, mappings)
     logging.debug("OVS external networking changes: %s", changes)
 
     mappings = update_mappings_from_rename(mappings, changes["renamed_bridges"])
+
+    if len(mappings) > 1 and external_bridge_address != IPVANYNETWORK_UNSET:
+        logging.warning(
+            "External bridge address configuration is supported only for localnet (i.e. no external nics)."
+        )
+        return
 
     for bridge, change in changes["interface_changes"].items():
         for iface in change["removed"]:
@@ -218,6 +353,21 @@ def configure_ovn_external_networking(
 
     for mapping in mappings:
         _wait_for_interface(mapping.bridge)
+
+    comment = "openstack-network-agents external network rule"
+    if len(mappings) == 1 and external_bridge_address != IPVANYNETWORK_UNSET:
+        # We only support localnet mode for a single virtual physnet
+        mapping = mappings[0]
+        logging.info(f"configuring external bridge {mapping.bridge}")
+        _add_ip_to_interface(mapping.bridge, external_bridge_address)
+        external_network = ipaddress.ip_interface(external_bridge_address).network
+        _add_iptable_postrouting_rule(str(external_network), comment)
+        # This is always gateway as single node only with localnet
+        _enable_chassis_as_gateway(ovs_cli)
+        return
+
+    # We're in external net mode
+    _delete_iptable_postrouting_rule(comment)
 
     for mapping in mappings:
         logging.info(f"Resetting external bridge {mapping.bridge} configuration")

--- a/openstack_network_agents/hooks/common.py
+++ b/openstack_network_agents/hooks/common.py
@@ -9,6 +9,7 @@ from snaphelpers import Snap
 logger = logging.getLogger(__name__)
 
 UNSET = ""
+IPVANYNETWORK_UNSET = "0.0.0.0/0"
 DEFAULT_CONFIG = {
     "logging.debug": "false",
     # Deprecated
@@ -19,6 +20,8 @@ DEFAULT_CONFIG = {
     "network.physnet": "physnet1",
     "network.bridge-mapping": UNSET,
     "network.enable-chassis-as-gw": "true",
+    # Only useful for local network (no remote interface)
+    "network.external-bridge-address": IPVANYNETWORK_UNSET,
 }
 
 

--- a/openstack_network_agents/hooks/configure.py
+++ b/openstack_network_agents/hooks/configure.py
@@ -40,6 +40,7 @@ def _configure_ovn_external_networking(snap: Snap) -> None:
         config("network.interface"),
         config("network.bridge-mapping"),
         config("network.enable-chassis-as-gw") in ("true", True),
+        config("network.external-bridge-address"),
         ovs_cli,
     )
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,6 +39,7 @@ apps:
       - network
       - network-control
       - ovn-chassis
+      - firewall-control
 
 parts:
   openstack-network-agents:
@@ -60,6 +61,6 @@ parts:
 
 hooks:
   install:
-    plugs: [network, network-control, ovn-chassis]
+    plugs: [network, network-control, ovn-chassis, firewall-control]
   configure:
-    plugs: [network, network-control, ovn-chassis]
+    plugs: [network, network-control, ovn-chassis, firewall-control]

--- a/tests/unit/core/test_external_networking.py
+++ b/tests/unit/core/test_external_networking.py
@@ -10,6 +10,7 @@ import pytest
 from openstack_network_agents.core.external_networking import (
     configure_ovn_external_networking,
 )
+from openstack_network_agents.hooks.common import IPVANYNETWORK_UNSET
 
 # Module path for patching
 MODULE_PATH = "openstack_network_agents.core.external_networking"
@@ -51,6 +52,13 @@ def mock_external_networking_deps():
         patch(
             f"{MODULE_PATH}._disable_chassis_as_gateway"
         ) as mock_disable_chassis_as_gateway,
+        patch(f"{MODULE_PATH}._add_ip_to_interface") as mock_add_ip_to_interface,
+        patch(
+            f"{MODULE_PATH}._add_iptable_postrouting_rule"
+        ) as mock_add_iptable_postrouting_rule,
+        patch(
+            f"{MODULE_PATH}._delete_iptable_postrouting_rule"
+        ) as mock_delete_iptable_postrouting_rule,
     ):
         yield {
             "wait_for_interface": mock_wait_for_interface,
@@ -61,6 +69,9 @@ def mock_external_networking_deps():
             "get_machine_id": mock_get_machine_id,
             "enable_chassis_as_gateway": mock_enable_chassis_as_gateway,
             "disable_chassis_as_gateway": mock_disable_chassis_as_gateway,
+            "add_ip_to_interface": mock_add_ip_to_interface,
+            "add_iptable_postrouting_rule": mock_add_iptable_postrouting_rule,
+            "delete_iptable_postrouting_rule": mock_delete_iptable_postrouting_rule,
         }
 
 
@@ -84,6 +95,7 @@ class TestConfigureOvnExternalNetworking:
             interface="eth0",
             bridge_mapping="",
             enable_chassis_as_gw=True,
+            external_bridge_address=IPVANYNETWORK_UNSET,
             ovs_cli=mock_ovs_cli,
         )
 
@@ -129,6 +141,7 @@ class TestConfigureOvnExternalNetworking:
             interface="",
             bridge_mapping="",
             enable_chassis_as_gw=False,
+            external_bridge_address=IPVANYNETWORK_UNSET,
             ovs_cli=mock_ovs_cli,
         )
 
@@ -168,6 +181,7 @@ class TestConfigureOvnExternalNetworking:
             interface="eth0",
             bridge_mapping="",
             enable_chassis_as_gw=True,
+            external_bridge_address=IPVANYNETWORK_UNSET,
             ovs_cli=mock_ovs_cli,
         )
 
@@ -192,6 +206,7 @@ class TestConfigureOvnExternalNetworking:
             interface="eth0",
             bridge_mapping="br-new1:physnet1:eth0 br-new2:physnet2:eth1",
             enable_chassis_as_gw=True,
+            external_bridge_address=IPVANYNETWORK_UNSET,
             ovs_cli=mock_ovs_cli,
         )
 
@@ -229,6 +244,7 @@ class TestConfigureOvnExternalNetworking:
             interface="eth0",
             bridge_mapping="",
             enable_chassis_as_gw=True,
+            external_bridge_address=IPVANYNETWORK_UNSET,
             ovs_cli=mock_ovs_cli,
         )
 
@@ -263,6 +279,7 @@ class TestConfigureOvnExternalNetworking:
             interface="eth0",
             bridge_mapping="",
             enable_chassis_as_gw=True,
+            external_bridge_address=IPVANYNETWORK_UNSET,
             ovs_cli=mock_ovs_cli,
         )
 
@@ -290,6 +307,7 @@ class TestConfigureOvnExternalNetworking:
             interface="eth0",
             bridge_mapping="br-ex:physnet1:eth0 br-ex2:physnet2",
             enable_chassis_as_gw=True,
+            external_bridge_address=IPVANYNETWORK_UNSET,
             ovs_cli=mock_ovs_cli,
         )
 
@@ -341,6 +359,7 @@ class TestConfigureOvnExternalNetworking:
             interface="eth0",
             bridge_mapping="br-ex2:physnet2",
             enable_chassis_as_gw=True,
+            external_bridge_address=IPVANYNETWORK_UNSET,
             ovs_cli=mock_ovs_cli,
         )
 
@@ -379,6 +398,7 @@ class TestConfigureOvnExternalNetworking:
             interface="",
             bridge_mapping="",
             enable_chassis_as_gw=False,
+            external_bridge_address=IPVANYNETWORK_UNSET,
             ovs_cli=mock_ovs_cli,
         )
 
@@ -387,14 +407,7 @@ class TestConfigureOvnExternalNetworking:
         mocks["ensure_single_nic_on_bridge"].assert_not_called()
         mocks["ensure_link_up"].assert_not_called()
         mocks["del_external_nics_from_bridge"].assert_not_called()
-
-        # Verify empty mappings are set
-        mock_ovs_cli.set.assert_any_call(
-            "open",
-            ".",
-            "external_ids",
-            {"ovn-bridge-mappings": ""},
-        )
+        mock_ovs_cli.set.assert_not_called()
 
     def test_chassis_gateway_disabled(
         self,
@@ -413,6 +426,7 @@ class TestConfigureOvnExternalNetworking:
             interface="eth0",
             bridge_mapping="",
             enable_chassis_as_gw=False,
+            external_bridge_address=IPVANYNETWORK_UNSET,
             ovs_cli=mock_ovs_cli,
         )
 
@@ -448,6 +462,7 @@ class TestConfigureOvnExternalNetworking:
             interface="eth0",
             bridge_mapping="br-new:physnet-new:eth2",
             enable_chassis_as_gw=True,
+            external_bridge_address=IPVANYNETWORK_UNSET,
             ovs_cli=mock_ovs_cli,
         )
 
@@ -497,6 +512,7 @@ class TestConfigureOvnExternalNetworking:
             interface="eth0",
             bridge_mapping="br-ex2:physnet2",
             enable_chassis_as_gw=True,
+            external_bridge_address=IPVANYNETWORK_UNSET,
             ovs_cli=mock_ovs_cli,
         )
 
@@ -543,6 +559,7 @@ class TestConfigureOvnExternalNetworking:
             interface="eth0",
             bridge_mapping="",
             enable_chassis_as_gw=True,
+            external_bridge_address=IPVANYNETWORK_UNSET,
             ovs_cli=mock_ovs_cli,
         )
 
@@ -573,6 +590,7 @@ class TestConfigureOvnExternalNetworking:
             interface="eth0",
             bridge_mapping="",
             enable_chassis_as_gw=True,
+            external_bridge_address=IPVANYNETWORK_UNSET,
             ovs_cli=mock_ovs_cli,
         )
 
@@ -601,6 +619,7 @@ class TestConfigureOvnExternalNetworking:
             interface="eth0",
             bridge_mapping="",
             enable_chassis_as_gw=True,
+            external_bridge_address=IPVANYNETWORK_UNSET,
             ovs_cli=mock_ovs_cli,
         )
 
@@ -633,6 +652,7 @@ class TestConfigureOvnExternalNetworking:
             interface="",
             bridge_mapping="",
             enable_chassis_as_gw=False,
+            external_bridge_address=IPVANYNETWORK_UNSET,
             ovs_cli=mock_ovs_cli,
         )
 
@@ -664,5 +684,95 @@ class TestConfigureOvnExternalNetworking:
                 interface="eth0",
                 bridge_mapping="",
                 enable_chassis_as_gw=True,
+                external_bridge_address=IPVANYNETWORK_UNSET,
                 ovs_cli=mock_ovs_cli,
             )
+
+    def test_localnet_mode_with_multiple_mappings_fails(
+        self,
+        mock_external_networking_deps,
+        mock_ovs_cli,
+    ):
+        """Test that localnet mode with multiple bridge mappings returns early with warning."""
+        # Setup
+        mocks = mock_external_networking_deps
+        mocks["get_machine_id"].return_value = "test-machine-id"
+
+        # Execute - configure with multiple mappings and external_bridge_address set
+        # Using bridge_mapping parameter to create multiple mappings
+        configure_ovn_external_networking(
+            bridge="",
+            physnet="",
+            interface="",
+            bridge_mapping="br-ex:physnet1 br-ex2:physnet2",
+            enable_chassis_as_gw=True,
+            external_bridge_address="10.20.30.1/24",
+            ovs_cli=mock_ovs_cli,
+        )
+
+        # Verify that the function returns early without configuring anything
+        # No bridge mappings should be set since function returns early
+        mock_ovs_cli.set.assert_not_called()
+        mock_ovs_cli.add_bridge.assert_not_called()
+        mock_ovs_cli.del_bridge.assert_not_called()
+
+        # Localnet-specific operations should not be called
+        mocks["add_ip_to_interface"].assert_not_called()
+        mocks["add_iptable_postrouting_rule"].assert_not_called()
+        mocks["wait_for_interface"].assert_not_called()
+
+        # External network mode operations should not be called either
+        mocks["del_external_nics_from_bridge"].assert_not_called()
+        mocks["ensure_single_nic_on_bridge"].assert_not_called()
+        mocks["get_machine_id"].assert_not_called()
+        mocks["enable_chassis_as_gateway"].assert_not_called()
+        mocks["disable_chassis_as_gateway"].assert_not_called()
+
+    def test_localnet_mode_single_mapping_success(
+        self,
+        mock_external_networking_deps,
+        mock_ovs_cli,
+    ):
+        """Test successful localnet mode configuration with single bridge mapping."""
+        # Setup
+        mocks = mock_external_networking_deps
+        mocks["get_machine_id"].return_value = "test-machine-id"
+
+        # Execute - configure localnet with single mapping and external_bridge_address
+        configure_ovn_external_networking(
+            bridge="br-ex",
+            physnet="physnet1",
+            interface="",
+            bridge_mapping="",
+            enable_chassis_as_gw=False,  # This should be ignored in localnet mode
+            external_bridge_address="10.20.30.1/24",
+            ovs_cli=mock_ovs_cli,
+        )
+
+        # Verify bridge mappings are set
+        mock_ovs_cli.set.assert_any_call(
+            "open",
+            ".",
+            "external_ids",
+            {"ovn-bridge-mappings": "physnet1:br-ex"},
+        )
+
+        # Verify bridge is created or waited for
+        mocks["wait_for_interface"].assert_called_once_with("br-ex")
+
+        # Verify localnet-specific operations are called
+        mocks["add_ip_to_interface"].assert_called_once_with("br-ex", "10.20.30.1/24")
+        mocks["add_iptable_postrouting_rule"].assert_called_once_with(
+            "10.20.30.0/24",
+            "openstack-network-agents external network rule",
+        )
+
+        # Verify chassis is always enabled as gateway in localnet mode
+        mocks["enable_chassis_as_gateway"].assert_called_once_with(mock_ovs_cli)
+
+        # Verify external network mode operations are NOT called
+        mocks["del_external_nics_from_bridge"].assert_not_called()
+        mocks["ensure_single_nic_on_bridge"].assert_not_called()
+        mocks["ensure_link_up"].assert_not_called()
+        mocks["get_machine_id"].assert_not_called()
+        mocks["disable_chassis_as_gateway"].assert_not_called()


### PR DESCRIPTION
Enable local network configuration through the network.external-bridge-address
snap configuration option. This allows OpenStack network agents to operate
in localnet mode without requiring external network interfaces.

Key changes:
- Add network.external-bridge-address config option (defaults to 0.0.0.0/0)
- Configure IP addressing on OVS bridges for localnet mode
- Manage NAT iptables rules for localnet traffic forwarding
- Automatically enable chassis as gateway in localnet mode
- Add firewall-control plug to allow iptables management

Localnet mode only supports single physical network mappings. When multiple
mappings are detected, localnet configuration is skipped.

Requires:
- [x] #6 