### PR TITLE
tics: add prerequisite packages

### DIFF
--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -28,6 +28,7 @@ jobs:
           run: |
             uv sync --all-extras
             source .venv/bin/activate
+            echo PATH=$PATH >> $GITHUB_ENV
 
         - name: TICS
           uses: tiobe/tics-github-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev= [
     "ruff",
     "mypy"
 ]
+tics = ["pylint", "flake8"]
 
 [project.urls]
 "Homepage" = "https://github.com/canonical/snap-openstack-network-agents"


### PR DESCRIPTION
Add packages required for tics in pyporject.toml
Pass PATH env to GITHUB_PATH so that uv venv is
considered in tics execution