### PR TITLE
snap: derive version from git ref

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,6 +22,7 @@ source-code:
   - https://github.com/canonical/snap-openstack-network-agents
 base: core24
 version: "2025.1"
+adopt-info: snap-version
 license: Apache-2.0
 grade: stable
 confinement: strict
@@ -58,6 +59,21 @@ apps:
       - firewall-control
 
 parts:
+  snap-version:
+    plugin: nil
+    build-packages:
+      - git
+    override-build: |
+      set -eu
+      craftctl default
+      gitref="$(git -C "$CRAFT_PROJECT_DIR" rev-parse --short=8 HEAD)"
+      version="$(craftctl get version)-${gitref}"
+      git -C "$CRAFT_PROJECT_DIR" update-index -q --refresh
+      if ! git -C "$CRAFT_PROJECT_DIR" diff-index --quiet HEAD --; then
+        version="${version}+dirty"
+      fi
+      craftctl set version="${version}"
+
   openstack-network-agents:
     plugin: python
     source: .


### PR DESCRIPTION
Use snapcraft adopt-info to populate the snap version from the static release version and the current git ref at build time.

Append +dirty when tracked files differ from HEAD so local builds are visibly not from a clean checkout.


(cherry picked from commit f0d2de04fb71d9e5c230ed356b80abd63fcf4450)